### PR TITLE
build: consolidate compatible dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      android-test-dependencies:
+        patterns:
+          - "androidx.test.*"
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: npm
     directory: /
     schedule:
@@ -16,3 +23,7 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -45,8 +45,9 @@ jobs:
 
       - name: Install Android SDK components
         run: |
-          yes | sdkmanager --licenses >/dev/null || true
-          sdkmanager \
+          SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+          yes | "$SDKMANAGER" --licenses >/dev/null || true
+          "$SDKMANAGER" \
             'platforms;android-35' \
             'build-tools;35.0.0' \
             'ndk;29.0.14206865'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -31,14 +31,14 @@ jobs:
           cache: gradle
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
           cache: pip
           cache-dependency-path: tools/requirements.txt
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: npm
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload APKs and reports
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: fridabox-${{ github.sha }}
           if-no-files-found: warn

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 agp = "8.13.2"
 junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
+junitVersion = "1.3.0"
+espressoCore = "3.7.0"
 appcompat = "1.7.0"
 material = "1.12.0"
 constraintlayout = "2.2.0"
-kotlin = "1.9.23"
+kotlin = "2.4.10"
 coreKtx = "1.15.0"
 
 [libraries]
@@ -22,4 +22,3 @@ core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx"
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-


### PR DESCRIPTION
## Summary

- updates GitHub Actions runtime dependencies to v7
- updates Kotlin to 2.4.10 and Android test dependencies to their compatible current versions
- groups future Dependabot Android-test and GitHub Actions updates to reduce PR noise
- intentionally keeps AGP 8.13.2 and Gradle 8.14.5 because the proposed AGP 9.3 / Gradle 9.6.1 combination is outside Kotlin 2.4.10's fully supported range

## Validation

- `:app:compileDebugKotlin`
- `:Bcore:testDebugUnitTest`
- `:app:testDebugUnitTest`
- `npm ci --cache .npm-cache` (0 vulnerabilities)
- `python tools/build_frida_agents.py` with no generated-content diff

A full native Windows build is blocked locally by the NDK path-with-spaces limitation; GitHub Actions runs from a space-free Linux workspace and remains the authoritative APK/lint check.